### PR TITLE
PathCommand --write-config updated to Laravel 5

### DIFF
--- a/src/Iverberk/Larasearch/Commands/PathsCommand.php
+++ b/src/Iverberk/Larasearch/Commands/PathsCommand.php
@@ -310,13 +310,14 @@ class PathsCommand extends Command {
 	{
 		if ($this->option('write-config'))
 		{
-			$configDir = app_path() . '/config/packages/iverberk/larasearch';
+			$configFile = base_path() . '/config/larasearch.php';
+                        $configDir = base_path() . '/config';
 
-			if (!File::exists($configDir))
+			if (!File::exists($configFile))
 			{
 				if ($this->confirm('It appears that you have not yet published the larasearch config. Would you like to do this now?', false))
 				{
-					$this->call('config:publish', ['package' => 'iverberk/larasearch']);
+					$this->call('vendor:publish', ['package' => 'iverberk/larasearch']);
 				}
 				else
 				{


### PR DESCRIPTION
The command 'php artisan larasearch:paths --dir=app --relations 'App\MySearchableModel' --write-config' did not work any more.
Fix to reflect the changes in Laravel 5:
- config folder has now changed to /config/ + now checking for the larasearch.php file instead of the package config folder
- 'config:publish' is now 'vendor:publish'
